### PR TITLE
Add CSV file upload to Admin content uploader

### DIFF
--- a/Frontend/src/pages/Admin.tsx
+++ b/Frontend/src/pages/Admin.tsx
@@ -1,49 +1,114 @@
-import React, { useState } from 'react';
-import { Box, Button, TextField, Typography, Chip } from '@mui/material';
-import axios from 'axios';
+import React, { useState } from "react";
+import { Box, Button, TextField, Typography, Chip } from "@mui/material";
+import axios from "axios";
 
 const Admin: React.FC = () => {
-  const [title, setTitle] = useState('');
-  const [genres, setGenres] = useState('');
-  const [mood, setMood] = useState('');
-  const [platforms, setPlatforms] = useState('');
-  const [type, setType] = useState<'books' | 'movies' | 'tvseries'>('books');
-  const [message, setMessage] = useState('');
+  const [title, setTitle] = useState("");
+  const [genres, setGenres] = useState("");
+  const [mood, setMood] = useState("");
+  const [platforms, setPlatforms] = useState("");
+  const [type, setType] = useState<"books" | "movies" | "tvseries">("books");
+  const [message, setMessage] = useState("");
 
   const handleUpload = async () => {
     const payload = {
       title,
-      genres: genres.split(',').map(g => g.trim()),
+      genres: genres.split(",").map((g) => g.trim()),
       mood,
-      platforms: platforms.split(',').map(p => p.trim())
+      platforms: platforms.split(",").map((p) => p.trim()),
     };
 
     try {
-      const res = await axios.post(`http://localhost:12046/admin/${type}`, payload);
+      const res = await axios.post(
+        `http://localhost:12046/admin/upload-csv/${type}`,
+        payload
+      );
       setMessage(res.data);
     } catch (err: any) {
-      setMessage(err.response?.data || 'Upload failed.');
+      setMessage(err.response?.data || "Upload failed.");
     }
   };
 
   return (
     <Box sx={{ p: 4 }}>
-      <Typography variant="h5" gutterBottom>Admin Content Uploader</Typography>
+      <Typography variant="h5" gutterBottom>
+        Admin Content Uploader
+      </Typography>
 
-      <TextField fullWidth label="Title" value={title} onChange={e => setTitle(e.target.value)} sx={{ mb: 2 }} />
-      <TextField fullWidth label="Genres (comma-separated)" value={genres} onChange={e => setGenres(e.target.value)} sx={{ mb: 2 }} />
-      <TextField fullWidth label="Mood" value={mood} onChange={e => setMood(e.target.value)} sx={{ mb: 2 }} />
-      <TextField fullWidth label="Platforms (comma-separated)" value={platforms} onChange={e => setPlatforms(e.target.value)} sx={{ mb: 2 }} />
+      <TextField
+        fullWidth
+        label="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <TextField
+        fullWidth
+        label="Genres (comma-separated)"
+        value={genres}
+        onChange={(e) => setGenres(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <TextField
+        fullWidth
+        label="Mood"
+        value={mood}
+        onChange={(e) => setMood(e.target.value)}
+        sx={{ mb: 2 }}
+      />
+      <TextField
+        fullWidth
+        label="Platforms (comma-separated)"
+        value={platforms}
+        onChange={(e) => setPlatforms(e.target.value)}
+        sx={{ mb: 2 }}
+      />
 
-      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-        <Chip label="Book" color={type === 'books' ? 'primary' : 'default'} onClick={() => setType('books')} />
-        <Chip label="Movie" color={type === 'movies' ? 'primary' : 'default'} onClick={() => setType('movies')} />
-        <Chip label="TV Series" color={type === 'tvseries' ? 'primary' : 'default'} onClick={() => setType('tvseries')} />
+      <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
+        <Chip
+          label="Book"
+          color={type === "books" ? "primary" : "default"}
+          onClick={() => setType("books")}
+        />
+        <Chip
+          label="Movie"
+          color={type === "movies" ? "primary" : "default"}
+          onClick={() => setType("movies")}
+        />
+        <Chip
+          label="TV Series"
+          color={type === "tvseries" ? "primary" : "default"}
+          onClick={() => setType("tvseries")}
+        />
       </Box>
 
-      <Button variant="contained" onClick={handleUpload}>Upload {type}</Button>
+      <Button variant="contained" onClick={handleUpload}>
+        Upload {type}
+      </Button>
 
-      {message && <Typography sx={{ mt: 2 }} color="secondary">{message}</Typography>}
+      {message && (
+        <Typography sx={{ mt: 2 }} color="secondary">
+          {message}
+        </Typography>
+      )}
+      <input
+        type="file"
+        accept=".csv"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (!file) return;
+
+          const formData = new FormData();
+          formData.append("file", file);
+
+          axios
+            .post(`http://localhost:12046/admin/upload-csv/${type}`, formData, {
+              headers: { "Content-Type": "multipart/form-data" },
+            })
+            .then((res) => setMessage(res.data))
+            .catch((err) => setMessage("Upload failed: " + err.message));
+        }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
Enhanced the Admin page to support uploading content via CSV files in addition to manual entry. The file input sends the selected CSV to the backend endpoint, improving bulk content management.